### PR TITLE
To be merged with env updates

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -136,14 +136,12 @@
        "1958-04-26  316.4"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "\n",
-    "# Load the \"co2\" dataset from sm.datasets\n",
     "# Load the \"co2\" dataset from sm.datasets\n",
     "data_set = sm.datasets.co2.load()\n",
     "\n",
@@ -159,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -225,7 +223,7 @@
        "1958-04-26  316.4"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 10,
    "metadata": {
     "scrolled": true
    },
@@ -284,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -355,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -389,7 +387,7 @@
        "              dtype='datetime64[ns]', name='date', length=2284, freq=None)"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -441,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -485,7 +483,7 @@
        "Freq: MS, Name: co2, dtype: float64"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -564,7 +562,7 @@
        "Freq: MS, Name: co2, Length: 144, dtype: float64"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -592,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -639,7 +637,7 @@
        "Freq: MS, Name: co2, dtype: float64"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -676,7 +674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -696,7 +694,7 @@
        "5"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -718,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -730,7 +728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -739,7 +737,7 @@
        "0"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,1 +1,779 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Managing Time Series Data - Lab\n", "\n", "## Introduction\n", "\n", "In the previous lecture, you learned that time series data are everywhere and understanding time series data is an important skill for data scientists!\n", "\n", "In this lab, you'll practice your previously learned techniques to import/load, clean and manipulate time series data.\n", "\n", "The lab will cover how to perform time series analysis while working with large datasets. The dataset can be memory intensive so your computer will need at least 2GB of memory to perform some of the calculations.\n", "\n", "\n", "## Objectives\n", "\n", "You will be able to:\n", "\n", "* Load time series data using Pandas and perform time series indexing\n", "* Perform index based slicing to create subsets of a time series\n", "* Change the granularity of a time series \n", "* Perform basic data cleaning operations on time series data\n", "\n", "## Let's get started!\n", "\n", "We will start the lab by loading the required libraries \n", "\n", "* `pandas` for data wrangling and manipulations  \n", "* `matplotlib` for visualizing time series data \n", "* `statsmodels` primarily for bundled datasets "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Load required libraries\n"]}, {"cell_type": "code", "execution_count": 3, "metadata": {}, "outputs": [], "source": ["# __SOLUTION__ \n", "# Load required libraries\n", "import pandas as pd\n", "import pandas.tseries\n", "import statsmodels.api as sm\n", "import matplotlib.pyplot as plt"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Loading time series data\n", "The `StatsModels` library comes bundled with built-in datasets for experimentation and practice. A detailed description of these datasets can be found [here](http://www.statsmodels.org/dev/datasets/index.html). Using `StatsModels`, the time series datasets can be loaded straight into memory. \n", "\n", "In this lab, we'll use the **\"Atmospheric CO2 from Continuous Air Samples at Mauna Loa Observatory, Hawaii, U.S.A.\"**, containing CO2 samples from March 1958 to December 2001. Further details on this dataset are available [here](http://www.statsmodels.org/dev/datasets/generated/co2.html).\n", "\n", "We can bring in this data using the `load()` method, which will allow us to read this data into a pandas dataframe by using `dataset[\"data\"]` and setting the index to the time series data.  "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["\n", "# Load the \"co2\" dataset from sm.datasets\n", "data_set = sm.datasets.co2.load()\n", "# load in the data_set into pandas data_frame\n", "CO2 = pd.DataFrame(data=data_set[\"data\"])\n", "# create index with frequency and periods\n", "index = pd.DatetimeIndex(data=CO2[\"date\"].str.decode(\"utf-8\"), freq='W-SAT', periods=CO2.date.size)\n", "# set index to date column\n", "CO2.set_index(index, inplace=True)\n", "# drop date column from table\n", "CO2.drop(\"date\", inplace=True, axis=1)\n", "CO2.head()"]}, {"cell_type": "code", "execution_count": 4, "metadata": {}, "outputs": [{"data": {"text/html": ["<div>\n", "<style scoped>\n", "    .dataframe tbody tr th:only-of-type {\n", "        vertical-align: middle;\n", "    }\n", "\n", "    .dataframe tbody tr th {\n", "        vertical-align: top;\n", "    }\n", "\n", "    .dataframe thead th {\n", "        text-align: right;\n", "    }\n", "</style>\n", "<table border=\"1\" class=\"dataframe\">\n", "  <thead>\n", "    <tr style=\"text-align: right;\">\n", "      <th></th>\n", "      <th>co2</th>\n", "    </tr>\n", "    <tr>\n", "      <th>date</th>\n", "      <th></th>\n", "    </tr>\n", "  </thead>\n", "  <tbody>\n", "    <tr>\n", "      <th>1958-03-29</th>\n", "      <td>316.1</td>\n", "    </tr>\n", "    <tr>\n", "      <th>1958-04-05</th>\n", "      <td>317.3</td>\n", "    </tr>\n", "    <tr>\n", "      <th>1958-04-12</th>\n", "      <td>317.6</td>\n", "    </tr>\n", "    <tr>\n", "      <th>1958-04-19</th>\n", "      <td>317.5</td>\n", "    </tr>\n", "    <tr>\n", "      <th>1958-04-26</th>\n", "      <td>316.4</td>\n", "    </tr>\n", "  </tbody>\n", "</table>\n", "</div>"], "text/plain": ["              co2\n", "date             \n", "1958-03-29  316.1\n", "1958-04-05  317.3\n", "1958-04-12  317.6\n", "1958-04-19  317.5\n", "1958-04-26  316.4"]}, "execution_count": 4, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# Load the \"co2\" dataset from sm.datasets\n", "data_set = sm.datasets.co2.load()\n", "# load in the data_set into pandas data_frame\n", "CO2 = pd.DataFrame(data=data_set[\"data\"])\n", "# create index with frequency and periods\n", "index = pd.DatetimeIndex(data=CO2[\"date\"].str.decode(\"utf-8\"), freq='W-SAT', periods=CO2.date.size)\n", "# set index to date column\n", "CO2.set_index(index, inplace=True)\n", "# drop date column from table\n", "CO2.drop(\"date\", inplace=True, axis=1)\n", "CO2.head()\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Let's check the type of CO2 and also first 15 entries of CO2 dataframe as our first exploratory step."]}, {"cell_type": "code", "execution_count": null, "metadata": {"scrolled": true}, "outputs": [], "source": ["# Print the datatype of CO2 and check first 15 values\n", "\n", "# datatype of CO2 is <class 'pandas.core.frame.DataFrame'>\n", "\n", "#               co2\n", "# 1958-03-29  316.1\n", "# 1958-04-05  317.3\n", "# 1958-04-12  317.6\n", "# 1958-04-19  317.5\n", "# 1958-04-26  316.4\n", "# 1958-05-03  316.9\n", "# 1958-05-10    NaN\n", "# 1958-05-17  317.5\n", "# 1958-05-24  317.9\n", "# 1958-05-31    NaN\n", "# 1958-06-07    NaN\n", "# 1958-06-14    NaN\n", "# 1958-06-21    NaN\n", "# 1958-06-28    NaN\n", "# 1958-07-05  315.8"]}, {"cell_type": "code", "execution_count": 5, "metadata": {"scrolled": true}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["<class 'pandas.core.frame.DataFrame'>\n", "              co2\n", "date             \n", "1958-03-29  316.1\n", "1958-04-05  317.3\n", "1958-04-12  317.6\n", "1958-04-19  317.5\n", "1958-04-26  316.4\n", "1958-05-03  316.9\n", "1958-05-10    NaN\n", "1958-05-17  317.5\n", "1958-05-24  317.9\n", "1958-05-31    NaN\n", "1958-06-07    NaN\n", "1958-06-14    NaN\n", "1958-06-21    NaN\n", "1958-06-28    NaN\n", "1958-07-05  315.8\n"]}], "source": ["# __SOLUTION__ \n", "# Print the datatype of CO2 and check first 15 values\n", "print(type(CO2))\n", "print(CO2.head(15))\n", "\n", "# datatype of CO2 is <class 'pandas.core.frame.DataFrame'>\n", "\n", "#               co2\n", "# 1958-03-29  316.1\n", "# 1958-04-05  317.3\n", "# 1958-04-12  317.6\n", "# 1958-04-19  317.5\n", "# 1958-04-26  316.4\n", "# 1958-05-03  316.9\n", "# 1958-05-10    NaN\n", "# 1958-05-17  317.5\n", "# 1958-05-24  317.9\n", "# 1958-05-31    NaN\n", "# 1958-06-07    NaN\n", "# 1958-06-14    NaN\n", "# 1958-06-21    NaN\n", "# 1958-06-28    NaN\n", "# 1958-07-05  315.8"]}, {"cell_type": "markdown", "metadata": {}, "source": ["With all the required packages imported and the CO2 dataset as a Dataframe ready to go, we can move on to indexing our data.\n", "\n", "## Data Indexing\n", "\n", "You may have noticed that by default, the dates have been set as the index of our pandas DataFrame. While working with time series data in Python, it's important to always ensure that dates are used as index values and are set as a `timestamp` object. Timestamp is the pandas equivalent of python\u2019s `Datetime` and is interchangeable with it in most cases. It's the type used for the entries that make up a `DatetimeIndex`, and other time series oriented data structures in pandas. Further details can be found [here](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Timestamp.html).\n", "\n", "We can confirm these assumption in python by checking index values of a pandas dataframe with `DataFrame.index`. "]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Confirm that date values are used for indexing purpose in the CO2 dataset \n", "\n", "# DatetimeIndex(['1958-03-29', '1958-04-05', '1958-04-12', '1958-04-19',\n", "#                '1958-04-26', '1958-05-03', '1958-05-10', '1958-05-17',\n", "#                '1958-05-24', '1958-05-31',\n", "#                ...\n", "#                '2001-10-27', '2001-11-03', '2001-11-10', '2001-11-17',\n", "#                '2001-11-24', '2001-12-01', '2001-12-08', '2001-12-15',\n", "#                '2001-12-22', '2001-12-29'],\n", "#               dtype='datetime64[ns]', length=2284, freq='W-SAT')"]}, {"cell_type": "code", "execution_count": 5, "metadata": {}, "outputs": [{"data": {"text/plain": ["DatetimeIndex(['1958-03-29', '1958-04-05', '1958-04-12', '1958-04-19',\n", "               '1958-04-26', '1958-05-03', '1958-05-10', '1958-05-17',\n", "               '1958-05-24', '1958-05-31',\n", "               ...\n", "               '2001-10-27', '2001-11-03', '2001-11-10', '2001-11-17',\n", "               '2001-11-24', '2001-12-01', '2001-12-08', '2001-12-15',\n", "               '2001-12-22', '2001-12-29'],\n", "              dtype='datetime64[ns]', length=2284, freq='W-SAT')"]}, "execution_count": 5, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# Confirm that date values are used for indexing purpose in the CO2 dataset \n", "CO2.index\n", "\n", "# DatetimeIndex(['1958-03-29', '1958-04-05', '1958-04-12', '1958-04-19',\n", "#                '1958-04-26', '1958-05-03', '1958-05-10', '1958-05-17',\n", "#                '1958-05-24', '1958-05-31',\n", "#                ...\n", "#                '2001-10-27', '2001-11-03', '2001-11-10', '2001-11-17',\n", "#                '2001-11-24', '2001-12-01', '2001-12-08', '2001-12-15',\n", "#                '2001-12-22', '2001-12-29'],\n", "#               dtype='datetime64[ns]', length=2284, freq='W-SAT')"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The output above shows that our dataset clearly fulfills the indexing requirements. Look at the last line:\n", "\n", "\n", "### **dtype='datetime64[ns]', length=2284, freq='W-SAT'**\n", "\n", "\n", "* `dtype=datetime[ns]` field confirms that the index is made of timestamp objects.\n", "* `length=2284` shows the total number of entries in our time series data.\n", "* `freq='W-SAT'` tells us that we have 2,284 weekly (W) date stamps starting on Saturdays (SAT).\n", "\n", "## Resampling\n", "\n", "Remember that depending on the nature of analytical question, the resolution of timestamps can also be changed to other frequencies. For this data set we can resample to monthly CO2 consumption values. This can be obtained by using the `resample() function`. Let's\n", "\n", "* Group the time-series into buckets representing 1 month using `resample()` function.\n", "* Apply a `mean()`function on each group (i.e. get monthly average).\n", "* Combine the result as one row per monthly group."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Group the timeseries into monthly buckets\n", "# Take the mean of each group \n", "# get the first 10 elements of resulting timeseries\n", "\n", "\n", "# 1958-03-01    316.100000\n", "# 1958-04-01    317.200000\n", "# 1958-05-01    317.433333\n", "# 1958-06-01           NaN\n", "# 1958-07-01    315.625000\n", "# 1958-08-01    314.950000\n", "# 1958-09-01    313.500000\n", "# 1958-10-01           NaN\n", "# 1958-11-01    313.425000\n", "# 1958-12-01    314.700000\n", "# Freq: MS, Name: co2, dtype: float64"]}, {"cell_type": "code", "execution_count": 11, "metadata": {}, "outputs": [{"data": {"text/plain": ["1958-03-01    316.100000\n", "1958-04-01    317.200000\n", "1958-05-01    317.433333\n", "1958-06-01           NaN\n", "1958-07-01    315.625000\n", "1958-08-01    314.950000\n", "1958-09-01    313.500000\n", "1958-10-01           NaN\n", "1958-11-01    313.425000\n", "1958-12-01    314.700000\n", "Freq: MS, Name: co2, dtype: float64"]}, "execution_count": 11, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# Group the timeseries into monthly buckets\n", "# Take the mean of each group \n", "# get the first 10 elements of resulting timeseries\n", "\n", "CO2_monthly= CO2['co2'].resample('MS')\n", "CO2_monthly_mean = CO2_monthly.mean()\n", "\n", "CO2_monthly_mean.head(10)\n", "\n", "# 1958-03-01    316.100000\n", "# 1958-04-01    317.200000\n", "# 1958-05-01    317.433333\n", "# 1958-06-01           NaN\n", "# 1958-07-01    315.625000\n", "# 1958-08-01    314.950000\n", "# 1958-09-01    313.500000\n", "# 1958-10-01           NaN\n", "# 1958-11-01    313.425000\n", "# 1958-12-01    314.700000\n", "# Freq: MS, Name: co2, dtype: float64"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Looking at the index values, we can see that our time series now carries aggregated data on monthly terms, shown as `Freq: MS`. \n", "\n", "### Time-series Index Slicing for Data Selection\n", "\n", "Slice our dataset to only retrieve data points that come after the year 1990."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Slice the timeseries to contain data after year 1990. \n", "\n", "# 1990-01-01    353.650\n", "# 1990-02-01    354.650\n", "#                ...   \n", "# 2001-11-01    369.375\n", "# 2001-12-01    371.020\n", "# Freq: MS, Name: co2, Length: 144, dtype: float64"]}, {"cell_type": "code", "execution_count": 12, "metadata": {}, "outputs": [{"data": {"text/plain": ["1990-01-01    353.650\n", "1990-02-01    354.650\n", "1990-03-01    355.480\n", "1990-04-01    356.175\n", "1990-05-01    357.075\n", "1990-06-01    356.080\n", "1990-07-01    354.675\n", "1990-08-01    352.900\n", "1990-09-01    350.940\n", "1990-10-01    351.225\n", "1990-11-01    352.700\n", "1990-12-01    354.140\n", "1991-01-01    354.675\n", "1991-02-01    355.650\n", "1991-03-01    357.200\n", "1991-04-01    358.600\n", "1991-05-01    359.250\n", "1991-06-01    358.180\n", "1991-07-01    356.050\n", "1991-08-01    353.860\n", "1991-09-01    352.125\n", "1991-10-01    352.250\n", "1991-11-01    353.740\n", "1991-12-01    355.025\n", "1992-01-01    355.900\n", "1992-02-01    356.680\n", "1992-03-01    357.900\n", "1992-04-01    359.075\n", "1992-05-01    359.540\n", "1992-06-01    359.125\n", "               ...   \n", "1999-07-01    369.000\n", "1999-08-01    366.700\n", "1999-09-01    364.675\n", "1999-10-01    365.140\n", "1999-11-01    366.650\n", "1999-12-01    367.900\n", "2000-01-01    369.020\n", "2000-02-01    369.375\n", "2000-03-01    370.400\n", "2000-04-01    371.540\n", "2000-05-01    371.650\n", "2000-06-01    371.625\n", "2000-07-01    369.940\n", "2000-08-01    367.950\n", "2000-09-01    366.540\n", "2000-10-01    366.725\n", "2000-11-01    368.125\n", "2000-12-01    369.440\n", "2001-01-01    370.175\n", "2001-02-01    371.325\n", "2001-03-01    372.060\n", "2001-04-01    372.775\n", "2001-05-01    373.800\n", "2001-06-01    373.060\n", "2001-07-01    371.300\n", "2001-08-01    369.425\n", "2001-09-01    367.880\n", "2001-10-01    368.050\n", "2001-11-01    369.375\n", "2001-12-01    371.020\n", "Freq: MS, Name: co2, Length: 144, dtype: float64"]}, "execution_count": 12, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# Slice the timeseries to contain data after year 1990. \n", "\n", "CO2_monthly_mean['1990':]\n", "\n", "# 1990-01-01    353.650\n", "# 1990-02-01    354.650\n", "#                ...   \n", "# 2001-11-01    369.375\n", "# 2001-12-01    371.020\n", "# Freq: MS, Name: co2, Length: 144, dtype: float64"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Slice the time series for a given time interval. Let's try to retrieve data starting from Jan 1990 to Jan 1991."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Retrieve the data between 1st Jan 1990 to 1st Jan 1991\n", "\n", "# 1990-01-01    353.650\n", "# 1990-02-01    354.650\n", "# 1990-03-01    355.480\n", "# 1990-04-01    356.175\n", "# 1990-05-01    357.075\n", "# 1990-06-01    356.080\n", "# 1990-07-01    354.675\n", "# 1990-08-01    352.900\n", "# 1990-09-01    350.940\n", "# 1990-10-01    351.225\n", "# 1990-11-01    352.700\n", "# 1990-12-01    354.140\n", "# 1991-01-01    354.675\n", "# Freq: MS, Name: co2, dtype: float64"]}, {"cell_type": "code", "execution_count": 13, "metadata": {}, "outputs": [{"data": {"text/plain": ["1990-01-01    353.650\n", "1990-02-01    354.650\n", "1990-03-01    355.480\n", "1990-04-01    356.175\n", "1990-05-01    357.075\n", "1990-06-01    356.080\n", "1990-07-01    354.675\n", "1990-08-01    352.900\n", "1990-09-01    350.940\n", "1990-10-01    351.225\n", "1990-11-01    352.700\n", "1990-12-01    354.140\n", "1991-01-01    354.675\n", "Freq: MS, Name: co2, dtype: float64"]}, "execution_count": 13, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# Retrieve the data between 1st Jan 1990 to 1st Jan 1991\n", "CO2_monthly_mean['1990-01-01':'1991-01-01']\n", "\n", "# 1990-01-01    353.650\n", "# 1990-02-01    354.650\n", "# 1990-03-01    355.480\n", "# 1990-04-01    356.175\n", "# 1990-05-01    357.075\n", "# 1990-06-01    356.080\n", "# 1990-07-01    354.675\n", "# 1990-08-01    352.900\n", "# 1990-09-01    350.940\n", "# 1990-10-01    351.225\n", "# 1990-11-01    352.700\n", "# 1990-12-01    354.140\n", "# 1991-01-01    354.675\n", "# Freq: MS, Name: co2, dtype: float64"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Missing Values\n", "\n", "Check if there are missing values in the data set."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Get the total number of missing values in the time series\n", "\n", "# 5"]}, {"cell_type": "code", "execution_count": 14, "metadata": {}, "outputs": [{"data": {"text/plain": ["5"]}, "execution_count": 14, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# Get the total number of missing values in the time series\n", "CO2_monthly_mean.isnull().sum()\n", "\n", "# 5"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Remember that missing values can be filled in a multitude of ways. Look for the next valid entry in the time series and fills the gaps with this value. Next, check if your attempt was successful by checking for missing values again."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# perform backward filling of missing values\n", "# check again for missing values\n", "\n", "# 0"]}, {"cell_type": "code", "execution_count": 15, "metadata": {}, "outputs": [{"data": {"text/plain": ["0"]}, "execution_count": 15, "metadata": {}, "output_type": "execute_result"}], "source": ["# __SOLUTION__ \n", "# perform backward filling of missing values\n", "# check again for missing values\n", "\n", "CO2_final = CO2_monthly_mean.fillna(CO2_monthly_mean.ffill())\n", "CO2_final.isnull().sum()\n", "\n", "# 0"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Great! Now your time series are ready for visualization and further analysis.\n", "\n", "## Summary\n", "\n", "In this introductory lab, you learned how to create a time series object in Python using Pandas. You learned how to check timestamp values as the data index and you learned about basic data handling techniques for getting time-series data ready for further analysis."]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.6.8"}}, "nbformat": 4, "nbformat_minor": 2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Managing Time Series Data - Lab\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "In the previous lecture, you learned that time series data are everywhere and understanding time series data is an important skill for data scientists!\n",
+    "\n",
+    "In this lab, you'll practice your previously learned techniques to import/load, clean and manipulate time series data.\n",
+    "\n",
+    "The lab will cover how to perform time series analysis while working with large datasets. The dataset can be memory intensive so your computer will need at least 2GB of memory to perform some of the calculations.\n",
+    "\n",
+    "\n",
+    "## Objectives\n",
+    "\n",
+    "You will be able to:\n",
+    "\n",
+    "* Load time series data using Pandas and perform time series indexing\n",
+    "* Perform index based slicing to create subsets of a time series\n",
+    "* Change the granularity of a time series \n",
+    "* Perform basic data cleaning operations on time series data\n",
+    "\n",
+    "## Let's get started!\n",
+    "\n",
+    "We will start the lab by loading the required libraries \n",
+    "\n",
+    "* `pandas` for data wrangling and manipulations  \n",
+    "* `matplotlib` for visualizing time series data \n",
+    "* `statsmodels` primarily for bundled datasets "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load required libraries\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Load required libraries\n",
+    "import pandas as pd\n",
+    "import pandas.tseries\n",
+    "import statsmodels.api as sm\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading time series data\n",
+    "The `StatsModels` library comes bundled with built-in datasets for experimentation and practice. A detailed description of these datasets can be found [here](http://www.statsmodels.org/dev/datasets/index.html). Using `StatsModels`, the time series datasets can be loaded straight into memory. \n",
+    "\n",
+    "In this lab, we'll use the **\"Atmospheric CO2 from Continuous Air Samples at Mauna Loa Observatory, Hawaii, U.S.A.\"**, containing CO2 samples from March 1958 to December 2001. Further details on this dataset are available [here](http://www.statsmodels.org/dev/datasets/generated/co2.html).\n",
+    "\n",
+    "We can bring in this data using the `load()` method, which will allow us to read this data into a pandas dataframe by using `dataset[\"data\"]` and setting the index to the time series data.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>co2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>date</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1958-03-29</td>\n",
+       "      <td>316.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-05</td>\n",
+       "      <td>317.3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-12</td>\n",
+       "      <td>317.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-19</td>\n",
+       "      <td>317.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-26</td>\n",
+       "      <td>316.4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              co2\n",
+       "date             \n",
+       "1958-03-29  316.1\n",
+       "1958-04-05  317.3\n",
+       "1958-04-12  317.6\n",
+       "1958-04-19  317.5\n",
+       "1958-04-26  316.4"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "# Load the \"co2\" dataset from sm.datasets\n",
+    "# Load the \"co2\" dataset from sm.datasets\n",
+    "data_set = sm.datasets.co2.load()\n",
+    "\n",
+    "# load in the data_set into pandas data_frame\n",
+    "CO2 = pd.DataFrame(data=data_set[\"data\"])\n",
+    "CO2.rename(columns={\"index\": \"date\"}, inplace=True)\n",
+    "\n",
+    "# set index to date column\n",
+    "CO2.set_index('date', inplace=True)\n",
+    "\n",
+    "CO2.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>co2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>date</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1958-03-29</td>\n",
+       "      <td>316.1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-05</td>\n",
+       "      <td>317.3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-12</td>\n",
+       "      <td>317.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-19</td>\n",
+       "      <td>317.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1958-04-26</td>\n",
+       "      <td>316.4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              co2\n",
+       "date             \n",
+       "1958-03-29  316.1\n",
+       "1958-04-05  317.3\n",
+       "1958-04-12  317.6\n",
+       "1958-04-19  317.5\n",
+       "1958-04-26  316.4"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Load the \"co2\" dataset from sm.datasets\n",
+    "data_set = sm.datasets.co2.load()\n",
+    "\n",
+    "# load in the data_set into pandas data_frame\n",
+    "CO2 = pd.DataFrame(data=data_set[\"data\"])\n",
+    "CO2.rename(columns={\"index\": \"date\"}, inplace=True)\n",
+    "\n",
+    "# set index to date column\n",
+    "CO2.set_index('date', inplace=True)\n",
+    "\n",
+    "CO2.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's check the type of CO2 and also first 15 entries of CO2 dataframe as our first exploratory step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Print the datatype of CO2 and check first 15 values\n",
+    "\n",
+    "# datatype of CO2 is <class 'pandas.core.frame.DataFrame'>\n",
+    "\n",
+    "#               co2\n",
+    "# 1958-03-29  316.1\n",
+    "# 1958-04-05  317.3\n",
+    "# 1958-04-12  317.6\n",
+    "# 1958-04-19  317.5\n",
+    "# 1958-04-26  316.4\n",
+    "# 1958-05-03  316.9\n",
+    "# 1958-05-10    NaN\n",
+    "# 1958-05-17  317.5\n",
+    "# 1958-05-24  317.9\n",
+    "# 1958-05-31    NaN\n",
+    "# 1958-06-07    NaN\n",
+    "# 1958-06-14    NaN\n",
+    "# 1958-06-21    NaN\n",
+    "# 1958-06-28    NaN\n",
+    "# 1958-07-05  315.8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "              co2\n",
+      "date             \n",
+      "1958-03-29  316.1\n",
+      "1958-04-05  317.3\n",
+      "1958-04-12  317.6\n",
+      "1958-04-19  317.5\n",
+      "1958-04-26  316.4\n",
+      "1958-05-03  316.9\n",
+      "1958-05-10    NaN\n",
+      "1958-05-17  317.5\n",
+      "1958-05-24  317.9\n",
+      "1958-05-31    NaN\n",
+      "1958-06-07    NaN\n",
+      "1958-06-14    NaN\n",
+      "1958-06-21    NaN\n",
+      "1958-06-28    NaN\n",
+      "1958-07-05  315.8\n"
+     ]
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Print the datatype of CO2 and check first 15 values\n",
+    "print(type(CO2))\n",
+    "print(CO2.head(15))\n",
+    "\n",
+    "# datatype of CO2 is <class 'pandas.core.frame.DataFrame'>\n",
+    "\n",
+    "#               co2\n",
+    "# 1958-03-29  316.1\n",
+    "# 1958-04-05  317.3\n",
+    "# 1958-04-12  317.6\n",
+    "# 1958-04-19  317.5\n",
+    "# 1958-04-26  316.4\n",
+    "# 1958-05-03  316.9\n",
+    "# 1958-05-10    NaN\n",
+    "# 1958-05-17  317.5\n",
+    "# 1958-05-24  317.9\n",
+    "# 1958-05-31    NaN\n",
+    "# 1958-06-07    NaN\n",
+    "# 1958-06-14    NaN\n",
+    "# 1958-06-21    NaN\n",
+    "# 1958-06-28    NaN\n",
+    "# 1958-07-05  315.8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With all the required packages imported and the CO2 dataset as a Dataframe ready to go, we can move on to indexing our data.\n",
+    "\n",
+    "## Data Indexing\n",
+    "\n",
+    "You may have noticed that by default, the dates have been set as the index of our pandas DataFrame. While working with time series data in Python, it's important to always ensure that dates are used as index values and are set as a `timestamp` object. Timestamp is the pandas equivalent of python’s `Datetime` and is interchangeable with it in most cases. It's the type used for the entries that make up a `DatetimeIndex`, and other time series oriented data structures in pandas. Further details can be found [here](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Timestamp.html).\n",
+    "\n",
+    "We can confirm these assumption in python by checking index values of a pandas dataframe with `DataFrame.index`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Confirm that date values are used for indexing purpose in the CO2 dataset \n",
+    "\n",
+    "# DatetimeIndex(['1958-03-29', '1958-04-05', '1958-04-12', '1958-04-19',\n",
+    "#                '1958-04-26', '1958-05-03', '1958-05-10', '1958-05-17',\n",
+    "#                '1958-05-24', '1958-05-31',\n",
+    "#                ...\n",
+    "#                '2001-10-27', '2001-11-03', '2001-11-10', '2001-11-17',\n",
+    "#                '2001-11-24', '2001-12-01', '2001-12-08', '2001-12-15',\n",
+    "#                '2001-12-22', '2001-12-29'],\n",
+    "#               dtype='datetime64[ns]', length=2284, freq='W-SAT')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['1958-03-29', '1958-04-05', '1958-04-12', '1958-04-19',\n",
+       "               '1958-04-26', '1958-05-03', '1958-05-10', '1958-05-17',\n",
+       "               '1958-05-24', '1958-05-31',\n",
+       "               ...\n",
+       "               '2001-10-27', '2001-11-03', '2001-11-10', '2001-11-17',\n",
+       "               '2001-11-24', '2001-12-01', '2001-12-08', '2001-12-15',\n",
+       "               '2001-12-22', '2001-12-29'],\n",
+       "              dtype='datetime64[ns]', name='date', length=2284, freq=None)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Confirm that date values are used for indexing purpose in the CO2 dataset \n",
+    "CO2.index\n",
+    "\n",
+    "# DatetimeIndex(['1958-03-29', '1958-04-05', '1958-04-12', '1958-04-19',\n",
+    "#                '1958-04-26', '1958-05-03', '1958-05-10', '1958-05-17',\n",
+    "#                '1958-05-24', '1958-05-31',\n",
+    "#                ...\n",
+    "#                '2001-10-27', '2001-11-03', '2001-11-10', '2001-11-17',\n",
+    "#                '2001-11-24', '2001-12-01', '2001-12-08', '2001-12-15',\n",
+    "#                '2001-12-22', '2001-12-29'],\n",
+    "#               dtype='datetime64[ns]', length=2284, freq='W-SAT')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output above shows that our dataset clearly fulfills the indexing requirements. Look at the last line:\n",
+    "\n",
+    "\n",
+    "### **dtype='datetime64[ns]', length=2284, freq='W-SAT'**\n",
+    "\n",
+    "\n",
+    "* `dtype=datetime[ns]` field confirms that the index is made of timestamp objects.\n",
+    "* `length=2284` shows the total number of entries in our time series data.\n",
+    "* `freq='W-SAT'` tells us that we have 2,284 weekly (W) date stamps starting on Saturdays (SAT).\n",
+    "\n",
+    "## Resampling\n",
+    "\n",
+    "Remember that depending on the nature of analytical question, the resolution of timestamps can also be changed to other frequencies. For this data set we can resample to monthly CO2 consumption values. This can be obtained by using the `resample() function`. Let's\n",
+    "\n",
+    "* Group the time-series into buckets representing 1 month using `resample()` function.\n",
+    "* Apply a `mean()`function on each group (i.e. get monthly average).\n",
+    "* Combine the result as one row per monthly group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Group the timeseries into monthly buckets\n",
+    "# Take the mean of each group \n",
+    "# get the first 10 elements of resulting timeseries\n",
+    "\n",
+    "\n",
+    "# 1958-03-01    316.100000\n",
+    "# 1958-04-01    317.200000\n",
+    "# 1958-05-01    317.433333\n",
+    "# 1958-06-01           NaN\n",
+    "# 1958-07-01    315.625000\n",
+    "# 1958-08-01    314.950000\n",
+    "# 1958-09-01    313.500000\n",
+    "# 1958-10-01           NaN\n",
+    "# 1958-11-01    313.425000\n",
+    "# 1958-12-01    314.700000\n",
+    "# Freq: MS, Name: co2, dtype: float64"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "date\n",
+       "1958-03-01    316.100000\n",
+       "1958-04-01    317.200000\n",
+       "1958-05-01    317.433333\n",
+       "1958-06-01           NaN\n",
+       "1958-07-01    315.625000\n",
+       "1958-08-01    314.950000\n",
+       "1958-09-01    313.500000\n",
+       "1958-10-01           NaN\n",
+       "1958-11-01    313.425000\n",
+       "1958-12-01    314.700000\n",
+       "Freq: MS, Name: co2, dtype: float64"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Group the timeseries into monthly buckets\n",
+    "# Take the mean of each group \n",
+    "# get the first 10 elements of resulting timeseries\n",
+    "\n",
+    "CO2_monthly= CO2['co2'].resample('MS')\n",
+    "CO2_monthly_mean = CO2_monthly.mean()\n",
+    "\n",
+    "CO2_monthly_mean.head(10)\n",
+    "\n",
+    "# 1958-03-01    316.100000\n",
+    "# 1958-04-01    317.200000\n",
+    "# 1958-05-01    317.433333\n",
+    "# 1958-06-01           NaN\n",
+    "# 1958-07-01    315.625000\n",
+    "# 1958-08-01    314.950000\n",
+    "# 1958-09-01    313.500000\n",
+    "# 1958-10-01           NaN\n",
+    "# 1958-11-01    313.425000\n",
+    "# 1958-12-01    314.700000\n",
+    "# Freq: MS, Name: co2, dtype: float64"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at the index values, we can see that our time series now carries aggregated data on monthly terms, shown as `Freq: MS`. \n",
+    "\n",
+    "### Time-series Index Slicing for Data Selection\n",
+    "\n",
+    "Slice our dataset to only retrieve data points that come after the year 1990."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Slice the timeseries to contain data after year 1990. \n",
+    "\n",
+    "# 1990-01-01    353.650\n",
+    "# 1990-02-01    354.650\n",
+    "#                ...   \n",
+    "# 2001-11-01    369.375\n",
+    "# 2001-12-01    371.020\n",
+    "# Freq: MS, Name: co2, Length: 144, dtype: float64"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "date\n",
+       "1990-01-01    353.650\n",
+       "1990-02-01    354.650\n",
+       "1990-03-01    355.480\n",
+       "1990-04-01    356.175\n",
+       "1990-05-01    357.075\n",
+       "               ...   \n",
+       "2001-08-01    369.425\n",
+       "2001-09-01    367.880\n",
+       "2001-10-01    368.050\n",
+       "2001-11-01    369.375\n",
+       "2001-12-01    371.020\n",
+       "Freq: MS, Name: co2, Length: 144, dtype: float64"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Slice the timeseries to contain data after year 1990. \n",
+    "\n",
+    "CO2_monthly_mean['1990':]\n",
+    "\n",
+    "# 1990-01-01    353.650\n",
+    "# 1990-02-01    354.650\n",
+    "#                ...   \n",
+    "# 2001-11-01    369.375\n",
+    "# 2001-12-01    371.020\n",
+    "# Freq: MS, Name: co2, Length: 144, dtype: float64"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Slice the time series for a given time interval. Let's try to retrieve data starting from Jan 1990 to Jan 1991."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve the data between 1st Jan 1990 to 1st Jan 1991\n",
+    "\n",
+    "# 1990-01-01    353.650\n",
+    "# 1990-02-01    354.650\n",
+    "# 1990-03-01    355.480\n",
+    "# 1990-04-01    356.175\n",
+    "# 1990-05-01    357.075\n",
+    "# 1990-06-01    356.080\n",
+    "# 1990-07-01    354.675\n",
+    "# 1990-08-01    352.900\n",
+    "# 1990-09-01    350.940\n",
+    "# 1990-10-01    351.225\n",
+    "# 1990-11-01    352.700\n",
+    "# 1990-12-01    354.140\n",
+    "# 1991-01-01    354.675\n",
+    "# Freq: MS, Name: co2, dtype: float64"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "date\n",
+       "1990-01-01    353.650\n",
+       "1990-02-01    354.650\n",
+       "1990-03-01    355.480\n",
+       "1990-04-01    356.175\n",
+       "1990-05-01    357.075\n",
+       "1990-06-01    356.080\n",
+       "1990-07-01    354.675\n",
+       "1990-08-01    352.900\n",
+       "1990-09-01    350.940\n",
+       "1990-10-01    351.225\n",
+       "1990-11-01    352.700\n",
+       "1990-12-01    354.140\n",
+       "1991-01-01    354.675\n",
+       "Freq: MS, Name: co2, dtype: float64"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Retrieve the data between 1st Jan 1990 to 1st Jan 1991\n",
+    "CO2_monthly_mean['1990-01-01':'1991-01-01']\n",
+    "\n",
+    "# 1990-01-01    353.650\n",
+    "# 1990-02-01    354.650\n",
+    "# 1990-03-01    355.480\n",
+    "# 1990-04-01    356.175\n",
+    "# 1990-05-01    357.075\n",
+    "# 1990-06-01    356.080\n",
+    "# 1990-07-01    354.675\n",
+    "# 1990-08-01    352.900\n",
+    "# 1990-09-01    350.940\n",
+    "# 1990-10-01    351.225\n",
+    "# 1990-11-01    352.700\n",
+    "# 1990-12-01    354.140\n",
+    "# 1991-01-01    354.675\n",
+    "# Freq: MS, Name: co2, dtype: float64"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Missing Values\n",
+    "\n",
+    "Check if there are missing values in the data set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the total number of missing values in the time series\n",
+    "\n",
+    "# 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# Get the total number of missing values in the time series\n",
+    "CO2_monthly_mean.isnull().sum()\n",
+    "\n",
+    "# 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remember that missing values can be filled in a multitude of ways. Look for the next valid entry in the time series and fills the gaps with this value. Next, check if your attempt was successful by checking for missing values again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# perform backward filling of missing values\n",
+    "# check again for missing values\n",
+    "\n",
+    "# 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# __SOLUTION__ \n",
+    "# perform backward filling of missing values\n",
+    "# check again for missing values\n",
+    "\n",
+    "CO2_final = CO2_monthly_mean.fillna(CO2_monthly_mean.ffill())\n",
+    "CO2_final.isnull().sum()\n",
+    "\n",
+    "# 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! Now your time series are ready for visualization and further analysis.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "In this introductory lab, you learned how to create a time series object in Python using Pandas. You learned how to check timestamp values as the data index and you learned about basic data handling techniques for getting time-series data ready for further analysis."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
With a bumped up version of statsmodel the dataset gets read in slightly differently.. the main difference: the column formerly known as 'date' is named 'index', but isn't set as the actual index of the dataframe

New Code:
```
# Load the "co2" dataset from sm.datasets
data_set = sm.datasets.co2.load()

# load in the data_set into pandas data_frame
CO2 = pd.DataFrame(data=data_set["data"])
CO2.rename(columns={"index": "date"}, inplace=True)

# set index to date column
CO2.set_index('date', inplace=True)

CO2.head()
```